### PR TITLE
Allow benchmark using doc-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ class MyTest extends \PHPUnit_Framework_TestCase
 }
 ```
 
+## Using Annotations
+
+In order to allow users to setup a more personal benchmark method name, you can also
+declare your own benchmarks functions using annotations:
+
+```php
+/**
+ * @benchmark
+ */
+public function is_this_function_super_slow($b) {}
+```
+

--- a/src/MethodExtractor.php
+++ b/src/MethodExtractor.php
@@ -61,13 +61,23 @@ class MethodExtractor
         $callables = [];
 
         foreach ($methods as $method) {
-            $name = $method->getName();
-
-            if (strpos($name, "benchmark") === 0) {
-                $callables[] = $name;
+            if ($this->isBenchmark($method)) {
+                $callables[] = $method->getName();
             }
         }
 
         return $callables;
+    }
+
+    private function isBenchmark(ReflectionMethod $method)
+    {
+        $isBenchmark = false;
+        foreach ([$method->getName(), $method->getDocComment()] as $thing) {
+            if (preg_match("/@benchmark[ ]*\n|^benchmark[a-zA-Z0-9]+/i", $thing)) {
+                $isBenchmark = true;
+            }
+        }
+
+        return $isBenchmark;
     }
 }

--- a/tests/MethodExtractorTest.php
+++ b/tests/MethodExtractorTest.php
@@ -34,7 +34,7 @@ class MethodExtractorTest extends \PHPUnit_Framework_TestCase
         $class = new ReflectionClass($class);
         $callables = $extractor->getBenchmarksFrom($class->getMethods());
 
-        $this->assertCount(2, $callables);
+        $this->assertCount(3, $callables);
         $this->assertEquals("benchmarkTestCase", $callables[0]);
         $this->assertEquals("benchmarkTestCaseWithALongerDescription", $callables[1]);
     }
@@ -51,7 +51,7 @@ class MethodExtractorTest extends \PHPUnit_Framework_TestCase
         $class = new \Sut();
         $callables = $extractor->extractFrom($class);
 
-        $this->assertCount(2, $callables);
+        $this->assertCount(3, $callables);
         list($key, $callable) = $callables[0];
         $this->assertEquals('Sut::benchmarkTestCase', $key);
         $this->assertInstanceOf("Sut", $callable[0]);
@@ -60,6 +60,10 @@ class MethodExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Sut::benchmarkTestCaseWithALongerDescription', $key);
         $this->assertInstanceOf("Sut", $callable[0]);
         $this->assertEquals("benchmarkTestCaseWithALongerDescription", $callable[1]);
+        list($key, $callable) = $callables[2];
+        $this->assertEquals('Sut::withDocComment', $key);
+        $this->assertInstanceOf("Sut", $callable[0]);
+        $this->assertEquals("withDocComment", $callable[1]);
     }
 
     public function testCallables()
@@ -71,7 +75,6 @@ class MethodExtractorTest extends \PHPUnit_Framework_TestCase
         $extractor = new MethodExtractor($finder->reveal());
         $callables = $extractor->getCallables();
 
-        $this->assertCount(2, $callables);
+        $this->assertCount(3, $callables);
     }
-
 }

--- a/tests/test.php
+++ b/tests/test.php
@@ -19,7 +19,14 @@ class Sut
     /**
      * @benchmark
      */
-    public function something()
+    public function withDocComment($b)
+    {
+        for ($i=0; $i<$b->times(); $i++) {
+            usleep(1e2);
+        }
+    }
+
+    public function thisIsNotABenchmark()
     {
 
     }


### PR DESCRIPTION
In order to simplify the benchmark management we allows users to
specifies benchmarks with doc blocks.

``` php
/**
 * @benchmark
 */
public function isThisMethodSuperSlow($b)
{
    // ...
}
```
